### PR TITLE
add some convienience for library and cli use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ ed_private.json
 build
 
 .vscode
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "credgen-ts",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/lib.js",
   "dependencies": {
     "@tweedegolf/storage-abstraction": "^1.4.3",
     "@types/node": "^14.6.3",
     "commander": "^6.1.0",
     "commandpost": "^1.4.0",
+    "dotenv": "^8.2.0",
     "fastify": "^3.3.0",
     "glob": "^7.1.6",
     "node-base64-image": "^2.0.1",
@@ -21,6 +22,7 @@
   "scripts": {
     "test": "mocha -r ts-node/register src/**/*.spec.ts",
     "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build",
     "start": "node dist/index.js"
   },
   "repository": {
@@ -32,5 +34,8 @@
   "bugs": {
     "url": "https://github.com/digitalcredentials/credgen-ts/issues"
   },
-  "homepage": "https://github.com/digitalcredentials/credgen-ts#readme"
+  "homepage": "https://github.com/digitalcredentials/credgen-ts#readme",
+  "bin": {
+    "credgen": "./dist/index.js"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
+#!/usr/bin/env node
+
+import dotenv from "dotenv";
+import os from "os";
 import program, { parseOptions } from "commander";
 import { Storage } from '@tweedegolf/storage-abstraction';
 import { newCredentialFromProfiles } from "./credential";
 import { ProfileManager, getProfileManagers } from "./profiles";
 
+dotenv.config();
 
 function configure(c: program.Command, mgr: ProfileManager) {
   const profileType = c.name();
@@ -39,7 +44,7 @@ function configure(c: program.Command, mgr: ProfileManager) {
 
 const c = program.version('0.0.1').description('credential and credential profile generator');
 
-const url = "local:///Users/kim/projects/credgen-ts/profiles/issuers?mode=750";
+const url = process.env.CG_STORAGE_URL || `local://${os.homedir()}/credgen/profiles/issuers?mode=750`;
 const s = new Storage(url);
 
 const profileManagers = getProfileManagers(s);
@@ -74,5 +79,3 @@ c.command('generate')
 });
 
 program.parse(process.argv);
-
-

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,2 @@
+export * from "./profiles";
+export * from "./credential";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "lib": ["es6", "dom"],
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
library:

    ──┤stuart@gamera:pts/2├────┤/home/stuart/src/credgen-ts├┤master├──
    ──┤1432:Tue,22 Sep 20:✓├── node
    Welcome to Node.js v14.2.0.
    Type ".help" for more information.
    > const cg = require("credgen-ts");
    undefined
    > cg
    {
      IssuerString: [Getter],
      AchievementString: [Getter],
      CredentialTemplateString: [Getter],
      ProfileManager: [Getter],
      getProfileManagers: [Getter],
      Credential: [Getter],
      newCredentialFromProfiles: [Getter]
    }
    > 

CLI:

    ──┤stuart@gamera:pts/2├──────────────────┤/home/stuart/src/credgen-ts├┤libAndCli├──
    ──┤1507:Tue,22 Sep 20:✓├── credgen issuer ls
    []
    ──┤stuart@gamera:pts/2├──────────────────┤/home/stuart/src/credgen-ts├┤libAndCli├──
    ──┤1507:Tue,22 Sep 20:✓├── cp profiles/issuers/gatech3.json ~/credgen/profiles/issuers/
    ──┤stuart@gamera:pts/2├──────────────────┤/home/stuart/src/credgen-ts├┤libAndCli├──
    ──┤1508:Tue,22 Sep 20:✓├── credgen issuer ls
    [ 'gatech3' ]
    ──┤stuart@gamera:pts/2├──────────────────┤/home/stuart/src/credgen-ts├┤libAndCli├──
    ──┤1509:Tue,22 Sep 20:✓├── echo CG_STORAGE_URL='local:///home/stuart/src/credgen-ts/profiles/issuers?mode=750' > ./.env
    ──┤stuart@gamera:pts/2├──────────────────┤/home/stuart/src/credgen-ts├┤libAndCli├──
    ──┤1509:Tue,22 Sep 20:✓├── credgen issuer ls
    [ 'gatech3', 'gatech4', 'test', 'xpro' ]
